### PR TITLE
Handle Big Sur Notification Center agent

### DIFF
--- a/.macos
+++ b/.macos
@@ -97,7 +97,14 @@ defaults write com.apple.helpviewer DevMode -bool true
 sudo defaults write /Library/Preferences/com.apple.loginwindow AdminHostInfo HostName
 
 # Disable Notification Center and remove the menu bar icon
-launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist 2> /dev/null
+# Big Sur (11) renamed the agent to `usernoted`, so detect the macOS version
+# and unload the appropriate launch agent.
+macos_version="$(sw_vers -productVersion)"
+if [[ "${macos_version%%.*}" -ge 11 ]]; then
+  launchctl unload -w /System/Library/LaunchAgents/com.apple.usernoted.plist 2> /dev/null
+else
+  launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist 2> /dev/null
+fi
 
 # Disable automatic capitalization as it’s annoying when typing code
 defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false


### PR DESCRIPTION
## Summary
- Detect macOS version via `sw_vers`
- Use new launch agent path for Notification Center on Big Sur and later

## Testing
- `bash -n .macos`


------
https://chatgpt.com/codex/tasks/task_e_68ac6f5af95c8327a8cd7fc77e8c49c0