### PR TITLE
Handle zsh shell during bootstrap

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,5 @@
+# Load bash profile configurations
+if [ -f ~/.bash_profile ]; then
+  source ~/.bash_profile
+fi
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,6 +5,7 @@ cd "$(dirname "${BASH_SOURCE}")";
 git pull origin main;
 
 doIt() {
+	current_shell="$(echo "$SHELL")"
 	rsync --exclude ".git/" \
 		--exclude ".DS_Store" \
 		--exclude ".osx" \
@@ -12,7 +13,14 @@ doIt() {
 		--exclude "README.md" \
 		--exclude "LICENSE-MIT.txt" \
 		-avh --no-perms . ~;
-	source ~/.bash_profile;
+	if [[ "$current_shell" == *"zsh" ]]; then
+		if [ ! -e ~/.zshrc ]; then
+			ln -s ~/.bash_profile ~/.zshrc
+		fi
+		source ~/.zshrc
+	else
+		source ~/.bash_profile
+	fi
 }
 
 if [ "$1" = "--force" ] || [ "$1" = "-f" ]; then


### PR DESCRIPTION
## Summary
- Detect current shell and ensure `.zshrc` is created when using zsh
- Source `.zshrc` for zsh shells while keeping `.bash_profile` for other shells

## Testing
- `bash -n bootstrap.sh`
- `shellcheck bootstrap.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6f4374dc8327ac58bd55fa03f6c3