### PR TITLE
Remove Chrome swipe navigation overrides

### DIFF
--- a/.macos
+++ b/.macos
@@ -805,14 +805,6 @@ defaults write com.apple.messageshelper.MessageController SOInputLineSettings -d
 # Google Chrome & Google Chrome Canary                                        #
 ###############################################################################
 
-# Disable the all too sensitive backswipe on trackpads
-defaults write com.google.Chrome AppleEnableSwipeNavigateWithScrolls -bool false
-defaults write com.google.Chrome.canary AppleEnableSwipeNavigateWithScrolls -bool false
-
-# Disable the all too sensitive backswipe on Magic Mouse
-defaults write com.google.Chrome AppleEnableMouseSwipeNavigateWithScrolls -bool false
-defaults write com.google.Chrome.canary AppleEnableMouseSwipeNavigateWithScrolls -bool false
-
 # Use the system-native print preview dialog
 defaults write com.google.Chrome DisablePrintPreview -bool true
 defaults write com.google.Chrome.canary DisablePrintPreview -bool true


### PR DESCRIPTION
## Summary
- remove trackpad and Magic Mouse swipe navigation configuration for Chrome and Chrome Canary, leaving default behavior

## Testing
- `bash -n .macos`
- `shellcheck .macos` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y shellcheck` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68ac78f2b8408327885af093fe8611cb