### PR TITLE
Disable showing all filename extensions

### DIFF
--- a/.macos
+++ b/.macos
@@ -272,7 +272,7 @@ defaults write com.apple.finder ShowRemovableMediaOnDesktop -bool true
 #defaults write com.apple.finder AppleShowAllFiles -bool true
 
 # Finder: show all filename extensions
-defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+defaults write NSGlobalDomain AppleShowAllExtensions -bool false
 
 # Finder: show status bar
 defaults write com.apple.finder ShowStatusBar -bool true


### PR DESCRIPTION
## Summary
- stop forcing macOS to show all file name extensions by default

## Testing
- `shellcheck .macos` *(fails: command not found)*
- `killall Finder` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac78ebfb648327874baad8ba29c70e